### PR TITLE
CON-1454-When-COH-Is-Additional-Scenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,6 @@ config/credentials.yml.enc
 # Ignore test coverage files
 coverage/*
 
-# Ignore travis generated files, or files that are updated during the pipeline but dont need to be pushed to github/CF.
+# Ignore travis generated files, or files that are updated during the pipeline but dont need to be pushed to github/CF
 vendor/bundle/
 CF/*.manifest.yml

--- a/app/controllers/api/v1/data_migration_controller.rb
+++ b/app/controllers/api/v1/data_migration_controller.rb
@@ -121,12 +121,12 @@ module Api
         elsif @companies_and_duns_ids.length == 1 && schemes_check(@coh_scheme)
           primary_organisation(@coh_api_results[:identifier])
         elsif @companies_and_duns_ids.length == 1 && schemes_check(@duns_scheme)
-          companies_house_additional
+          company_house_additional
         end
         true
       end
 
-      def companies_house_additional
+      def company_house_additional
         if @duns_api_results[:additionalIdentifiers][0][:scheme] == @coh_scheme
           primary_organisation(@duns_api_results[:additionalIdentifiers][0])
           add_additional_identifiers([@duns_api_results[:identifier]])

--- a/app/controllers/api/v1/data_migration_controller.rb
+++ b/app/controllers/api/v1/data_migration_controller.rb
@@ -121,11 +121,19 @@ module Api
         elsif @companies_and_duns_ids.length == 1 && schemes_check(@coh_scheme)
           primary_organisation(@coh_api_results[:identifier])
         elsif @companies_and_duns_ids.length == 1 && schemes_check(@duns_scheme)
+          companies_house_additional
+        end
+        true
+      end
+
+      def companies_house_additional
+        if @duns_api_results[:additionalIdentifiers][0][:scheme] == @coh_scheme
+          primary_organisation(@duns_api_results[:additionalIdentifiers][0])
+          add_additional_identifiers([@duns_api_results[:identifier]])
+        else
           primary_organisation(@duns_api_results[:identifier])
           add_additional_identifiers(@duns_api_results[:additionalIdentifiers])
         end
-
-        true
       end
 
       def add_additional_identifiers(additional_identifiers)


### PR DESCRIPTION
https://crowncommercialservice.atlassian.net/browse/CON-1454

Unique scenario Amrutha found, where DUNs was being supplied as Primary identifier and COH as the additional. This fixes that issue, so COH is rightly the primary identifier and DUN is the additional, for the record.