### PR TITLE
Remove-Private-From-AccessToken-Controller

### DIFF
--- a/app/controllers/api/v1/testing/access_token_controller.rb
+++ b/app/controllers/api/v1/testing/access_token_controller.rb
@@ -9,8 +9,6 @@ module Api
           render_results(nil) unless params && params[:ccs_org_id] && params[:user_email]
         end
 
-        private
-
         def create_new_access_token
           organisation_id = org_creation(params[:ccs_org_id].to_s)
 

--- a/app/controllers/api/v1/testing/access_token_controller.rb
+++ b/app/controllers/api/v1/testing/access_token_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     module Testing
       class AccessTokenController < ActionController::API
+        # Testing endpoint, to generate an AccessToken for test purposes.
         require 'json'
         before_action :validate_params
 


### PR DESCRIPTION
_Note:_ The code climate checks for this PR are okay to have failed, as it's a test endpoint for Amrutha and the testing team to get an access token (not part of the spec, so no coverage/tests on the controller).