### PR TITLE
CON-2633-Constant-OrgID-Length

### DIFF
--- a/app/services/common/generate_id.rb
+++ b/app/services/common/generate_id.rb
@@ -1,7 +1,7 @@
 module Common
   class GenerateId
     def self.ccs_org_id
-      "#{rand(100000)}#{(Time.now.to_f.round(3) * 1000).to_i}"
+      "#{rand(10000..99999)}#{(Time.now.to_f.round(3) * 1000).to_i}"
     end
 
     def self.api_key


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/CON-2633**
Updates OrganisationID generator method to produce fixed length ID.