### PR TITLE
CON-1373-1453-Role-Based-Changes-to-Registered-Organisation-Controller

### DIFF
--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -160,5 +160,3 @@ cd .. || exit
 
 # CF Push
 cf push conclave-cii-"$CF_SPACE" -f CF/"$CF_SPACE".manifest.yml
-
-cf ssh conclave-cii-"$CF_SPACE" -t -c "/tmp/lifecycle/shell /home/vcap/app ''"

--- a/app/controllers/api/v1/registered_organisations_schemes_controller.rb
+++ b/app/controllers/api/v1/registered_organisations_schemes_controller.rb
@@ -9,7 +9,7 @@ module Api
       def search_organisation
         params[:ccs_org_id] = search_organisation_by_scheme if @scheme_id
 
-        result = Common::RegisteredOrganisationResponse.new(params[:ccs_org_id], hidden: validate_service_eligibility_or_ccs_admin_user).response_payload if params[:ccs_org_id]
+        result = Common::RegisteredOrganisationResponse.new(params[:ccs_org_id], hidden: registered_orgs_controller_role_check).response_payload if params[:ccs_org_id]
 
         if result.present?
           render json: build_response(result), status: :ok

--- a/app/services/authorize/user.rb
+++ b/app/services/authorize/user.rb
@@ -43,14 +43,14 @@ module Authorize
 
     def validate_service_eligibility_or_ccs_admin_user
       decoded_token = validate_and_decode_token
-      if decoded_token[0]['roles'].include?(ENV['ACCESS_MANAGE_SUBSCRIPTIONS'])
-        true
-      elsif decoded_token[0]['roles'].include?(ENV['ACCESS_CCS_ADMIN'])
-        false
-      else
-        ApiValidations::ApiErrorValidationResponse.new(:user_access_unauthorized)
-        false
-      end
+      ApiValidations::ApiErrorValidationResponse.new(:user_access_unauthorized) unless decoded_token[0]['roles'].include?(ENV['ACCESS_MANAGE_SUBSCRIPTIONS']) || decoded_token[0]['roles'].include?(ENV['ACCESS_ORGANISATION_ADMIN'])
+    end
+
+    def registered_orgs_controller_role_check
+      decoded_token = Common::ApiHelper.decode_token(request.headers)
+      return true if decoded_token.present? && decoded_token[0]['roles'].include?(ENV['ACCESS_MANAGE_SUBSCRIPTIONS'])
+
+      false
     end
 
     def validate_access_token

--- a/spec/controllers/api/v1/registered_organisations_schemes_controller_spec.rb
+++ b/spec/controllers/api/v1/registered_organisations_schemes_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::V1::RegisteredOrganisationsSchemesController, type: :control
   describe 'search_organisation' do
     let(:clientid) { ENV['CLIENT_ID'] }
     let(:ccs_org_id) { nil }
-    let(:jwt_token) { JWT.encode({ roles: ENV['ACCESS_CCS_ADMIN'], ciiOrgId: ccs_org_id, aud: ENV['CLIENT_ID'] }, 'test') }
+    let(:jwt_token) { JWT.encode({ roles: ENV['ACCESS_ORGANISATION_ADMIN'], ciiOrgId: ccs_org_id, aud: ENV['CLIENT_ID'] }, 'test') }
 
     context 'when authorized' do
       before do


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/CON-1373
https://crowncommercialservice.atlassian.net/browse/CON-1453**
Update existing _registered_organisations_controller_ to match the _all_registered_organisations_controller_, when the correct role is present. I.e. An admin or any other user will not see hidden identifiers, whereas a Service Eligibility user will see all, including the hidden.