### PR TITLE
CON-1373-Relax-Org-ID-Check-On-MSE-Role-For-Registered-Orgs

### DIFF
--- a/app/services/authorize/authorization_methods.rb
+++ b/app/services/authorize/authorization_methods.rb
@@ -61,7 +61,6 @@ module Authorize
       validate_user_access_token
       validate_access_token
       validate_service_eligibility_or_ccs_admin_user
-      validate_ccs_org_id
     end
   end
 end

--- a/app/services/authorize/authorization_methods.rb
+++ b/app/services/authorize/authorization_methods.rb
@@ -60,7 +60,7 @@ module Authorize
       validate_client_id
       validate_user_access_token
       validate_access_token
-      validate_service_eligibility_or_ccs_admin_user
+      validate_service_eligibility_or_ccs_admin_user(validate_and_decode_token)
     end
   end
 end

--- a/app/services/authorize/user.rb
+++ b/app/services/authorize/user.rb
@@ -42,7 +42,7 @@ module Authorize
     end
 
     def validate_service_eligibility_or_ccs_admin_user
-      decoded_token = validate_and_decode_token #validate_ccs_org_id
+      decoded_token = validate_and_decode_token
       if decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil)) || decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_ORGANISATION_ADMIN', nil))
         validate_ccs_org_id unless decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil))
       else

--- a/app/services/authorize/user.rb
+++ b/app/services/authorize/user.rb
@@ -41,13 +41,12 @@ module Authorize
       ApiValidations::ApiErrorValidationResponse.new(:user_access_unauthorized) unless decoded_token[0]['roles'].include?(ENV['ACCESS_MANAGE_SUBSCRIPTIONS'])
     end
 
-    def validate_service_eligibility_or_ccs_admin_user
-      decoded_token = validate_and_decode_token
+    def validate_service_eligibility_or_ccs_admin_user(decoded_token)
       if decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil)) || decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_ORGANISATION_ADMIN', nil))
-        validate_ccs_org_id unless decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil))
-      else
-        ApiValidations::ApiErrorValidationResponse.new(:user_access_unauthorized)
+        return validate_ccs_org_id unless decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil))
+
       end
+      ApiValidations::ApiErrorValidationResponse.new(:user_access_unauthorized)
     end
 
     def registered_orgs_controller_role_check

--- a/app/services/authorize/user.rb
+++ b/app/services/authorize/user.rb
@@ -42,8 +42,12 @@ module Authorize
     end
 
     def validate_service_eligibility_or_ccs_admin_user
-      decoded_token = validate_and_decode_token
-      ApiValidations::ApiErrorValidationResponse.new(:user_access_unauthorized) unless decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil)) || decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_ORGANISATION_ADMIN', nil))
+      decoded_token = validate_and_decode_token #validate_ccs_org_id
+      if decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil)) || decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_ORGANISATION_ADMIN', nil))
+        validate_ccs_org_id unless decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil))
+      else
+        ApiValidations::ApiErrorValidationResponse.new(:user_access_unauthorized)
+      end
     end
 
     def registered_orgs_controller_role_check

--- a/app/services/authorize/user.rb
+++ b/app/services/authorize/user.rb
@@ -42,10 +42,8 @@ module Authorize
     end
 
     def validate_service_eligibility_or_ccs_admin_user(decoded_token)
-      if decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil)) || decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_ORGANISATION_ADMIN', nil))
-        return validate_ccs_org_id unless decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil))
+      return validate_ccs_org_id if (decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil)) || decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_ORGANISATION_ADMIN', nil))) && decoded_token[0]['roles'].exclude?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil))
 
-      end
       ApiValidations::ApiErrorValidationResponse.new(:user_access_unauthorized)
     end
 


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/CON-1373**
Removes OrgID check when calling the registered_organisations_controller, when the role MSE is provided in a user access token.