### PR TITLE
CON-2784-Add-Salesforce-Schemes-To-Test-Org

### DIFF
--- a/app/controllers/api/v1/organisations_controller.rb
+++ b/app/controllers/api/v1/organisations_controller.rb
@@ -17,7 +17,7 @@ module Api
 
       def validate_params
         validate = ApiValidations::Scheme.new(params, return_organisation_id: true)
-        render json: validate.errors, status: :bad_request unless validate.valid?
+        render json: validate.errors, status: :bad_request unless params[:id] == Common::AdditionalIdentifier::MOCK_ID || validate.valid?
       end
 
       private

--- a/app/services/common/additional_identifier.rb
+++ b/app/services/common/additional_identifier.rb
@@ -13,6 +13,8 @@ module Common
     SCHEME_DANDB = 'US-DUN'.freeze
     SCHEME_NHS = 'GB-NHS'.freeze
     SCHEME_CCS = 'GB-CCS'.freeze
+    SCHEME_SF_ID = 'SF-ID'.freeze
+    SCHEME_SF_URN = 'SF-URN'.freeze
 
     # The below three constants are required to match the correct uri provided in the identifiers uri property.
     # If you change any of these variable names, it must also be updated in identifier.rb, in the module 'FindThatCharity'
@@ -21,7 +23,7 @@ module Common
     GB_SC_SCHEME_URI_SITE = 'Office of Scottish Charity Regulator'.freeze
 
     def schemes
-      [SCHEME_ENG_WALES_CHARITY, SCHEME_NORTHEN_IRELAND_CHARITY, SCHEME_SCOTISH_CHARITY, SCHEME_COMPANIES_HOUSE, SCHEME_DANDB, SCHEME_NHS]
+      [SCHEME_ENG_WALES_CHARITY, SCHEME_NORTHEN_IRELAND_CHARITY, SCHEME_SCOTISH_CHARITY, SCHEME_COMPANIES_HOUSE, SCHEME_DANDB, SCHEME_NHS, SCHEME_SF_ID, SCHEME_SF_URN]
     end
 
     def dandb_codes

--- a/spec/controllers/api/v1/create_organisations_controller_spec.rb
+++ b/spec/controllers/api/v1/create_organisations_controller_spec.rb
@@ -49,6 +49,24 @@ RSpec.describe Api::V1::CreateOrganisationsController, type: :controller do
         end
       end
 
+      context 'when POST test identifier Saleforce ID create an organisation record' do
+        it 'create primary record NHS' do
+          param_post_companies_house = { identifier: { scheme: 'SF-ID', id: '111111111' } }
+          post :index, params: param_post_companies_house
+          expect(response.status).to eq(201)
+          expect(response.body).to include('organisationId')
+        end
+      end
+
+      context 'when POST test identifier DUNs create an organisation record' do
+        it 'create primary record NHS' do
+          param_post_companies_house = { identifier: { scheme: 'US-DUN', id: '111111111' } }
+          post :index, params: param_post_companies_house
+          expect(response.status).to eq(201)
+          expect(response.body).to include('organisationId')
+        end
+      end
+
       context 'when POST invalid scheme does not save org' do
         it 'returns 404' do
           param_post_companies_house = { identifier: { scheme: 'US-DN', id: '111111111' } }

--- a/spec/controllers/api/v1/organisations_controller_spec.rb
+++ b/spec/controllers/api/v1/organisations_controller_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe Api::V1::OrganisationsController, type: :controller do
           expect(response.status).to eq(200)
         end
 
+        it 'search Find the duns test identifier SF-ID-1111....' do
+          get :search_organisation, params: { scheme: 'SF-ID', id: '111111111' }
+          expect(response.status).to eq(200)
+        end
+
+        it 'search Find the duns test identifier SF-URN-1111....' do
+          get :search_organisation, params: { scheme: 'SF-URN', id: '111111111' }
+          expect(response.status).to eq(200)
+        end
+
         it 'search Find the companies house test identifier GB-COH-1111....' do
           get :search_organisation, params: { scheme: 'US-DUN', id: '111111111' }
           expect(response.status).to eq(200)


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/CON-2784**
Adds the Salesforce schemes to the test organisation, when using the specified test ID.