### PR TITLE
CON-2784-Update-MockID-For-DM-Endpoint

### DIFF
--- a/app/controllers/api/v1/data_migration_controller.rb
+++ b/app/controllers/api/v1/data_migration_controller.rb
@@ -5,6 +5,8 @@ module Api
       rescue_from ApiValidations::ApiError, with: :return_error_code
       before_action :validate_integrating_service_user
       before_action :create_ccs_org_id
+      # This is checking for the dummy org (id: 111111111) in params. must be done first, to stop external api calls.
+      before_action :mock_id_check
 
       attr_accessor :ccs_org_id, :salesforce_result, :api_result, :sales_force_organisation_created
 
@@ -22,6 +24,8 @@ module Api
       end
 
       def create_org_profile
+        return mock_id_dm_helper if @is_mock_id
+
         schemes_list = Common::AdditionalIdentifier.new
         create_from_schemes if schemes_list.schemes.include? params[:account_id_type].to_s
         create_from_salesforce if Common::SalesforceSearchIds.account_id_types_salesforce.include? params[:account_id_type].to_s
@@ -39,6 +43,14 @@ module Api
         return render json: build_response, status: :created if @api_result.present?
 
         render json: '', status: :not_found if @api_result.blank?
+      end
+
+      def mock_id_dm_helper
+        # If the dummy org (id: 111111111) has been found, this will add it to db, and return the ccs_org_id to be rendered.
+        ccs_org_id = Common::ApiHelper.add_dummy_org(api_key_to_string, params[:account_id_type], true)
+        response_body = Common::ApiHelper.return_mock_organisation(params[:scheme])
+        response_body['organisationID'] = ccs_org_id.to_s
+        render json: response_body, status: :created
       end
 
       def create_from_salesforce
@@ -237,6 +249,11 @@ module Api
         @api_result[:additionalIdentifiers].each do |user_params|
           validate_additional_schemes(user_params) if user_params[:scheme] == Common::AdditionalIdentifier::SCHEME_CCS
         end
+      end
+
+      # This is checking for the dummy org (id: 111111111) in params. Sets global variable to true or false, for the rest of controller behavoir.
+      def mock_id_check
+        @is_mock_id = Common::ApiHelper.find_mock_organisation(params[:account_id_type], params[:account_id]) if params.present?
       end
     end
   end


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/CON-2784**
Adds the test organisation to DM endpoint, when using the specified test ID.