### PR TITLE
CON-2784-Fix-Test-Identifier-DM-Bug

### DIFF
--- a/app/controllers/api/v1/data_migration_controller.rb
+++ b/app/controllers/api/v1/data_migration_controller.rb
@@ -47,7 +47,7 @@ module Api
 
       def mock_id_dm_helper
         # If the dummy org (id: 111111111) has been found, this will add it to db, and return the ccs_org_id to be rendered.
-        ccs_org_id = Common::ApiHelper.add_dummy_org(api_key_to_string, params[:account_id_type], true)
+        ccs_org_id = Common::ApiHelper.add_dummy_org(nil, params[:account_id_type], true)
         response_body = Common::ApiHelper.return_mock_organisation(params[:scheme])
         response_body['organisationID'] = ccs_org_id.to_s
         render json: response_body, status: :created

--- a/app/services/common/api_helper.rb
+++ b/app/services/common/api_helper.rb
@@ -117,7 +117,7 @@ module Common
           scheme: scheme,
           id: Common::AdditionalIdentifier::MOCK_ID,
           legalName: 'Nicks Testing Organisation',
-          uri: ''
+          uri: 'https://www.example.com/'
         },
         additionalIdentifiers: [],
         address: {
@@ -128,11 +128,11 @@ module Common
           countryName: 'England'
         },
         contactPoint: {
-          name: '',
-          email: '',
+          name: 'Name',
+          email: 'email@test.com',
           telephone: '01234567890',
-          faxNumber: '',
-          uri: ''
+          faxNumber: '01234567890',
+          uri: 'https://www.example.com/'
         }
       }
     end

--- a/app/services/common/api_helper.rb
+++ b/app/services/common/api_helper.rb
@@ -89,7 +89,7 @@ module Common
       organisation.ccs_org_id = Common::GenerateId.ccs_org_id
       organisation.primary_scheme = primary_scheme_bool # true|false
       organisation.hidden = false
-      organisation.client_id = Common::ApiHelper.find_client(api_key_to_string)
+      organisation.client_id = Common::ApiHelper.find_client(api_key_to_string) if api_key_to_string
       organisation.save
       organisation.ccs_org_id
     end


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/CON-2784**
Fixes bug caused by `api_key_to_string` being missing, when test identifier is used.