### PR TITLE
CON-1373-Update-Authorisation-Check-For-MSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ This is the Conclave Central Identity Index (CII) API service.
 
 ## Nomenclature
 
-- **OrganisationSchemeIdentifier**: An organisation is an entity which may include multiple identifiers. A identifier is data related for an organisation for a scheme e.g. Companies House
-- **Scheme**: A scheme is an external register or reference agency
+- **OrganisationSchemeIdentifier**: An organisation is an entity which may include multiple identifiers. A identifier is data related for an organisation for a scheme e.g. Companies House.
+- **Scheme**: A scheme is an external register or reference agency.
 - **SchemeRegister**: Scheme Registers represent an Operator/Legal entity which used to provide unique identifiers for organisations sourced existing public available register lists exposed by existing API’s, e.g. Companies House.
 
 ## Technical documentation

--- a/app/services/authorize/user.rb
+++ b/app/services/authorize/user.rb
@@ -43,9 +43,15 @@ module Authorize
 
     def validate_service_eligibility_or_ccs_admin_user
       decoded_token = validate_and_decode_token
-      return validate_ccs_org_id if decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_ORGANISATION_ADMIN', nil)) && decoded_token[0]['roles'].exclude?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil))
+      if decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_ORGANISATION_ADMIN', nil)) && decoded_token[0]['roles'].exclude?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil))
+        return validate_ccs_org_id
 
-      ApiValidations::ApiErrorValidationResponse.new(:user_access_unauthorized) unless decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil))
+      elsif decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil))
+        return
+
+      end
+
+      ApiValidations::ApiErrorValidationResponse.new(:user_access_unauthorized)
     end
 
     def registered_orgs_controller_role_check

--- a/app/services/authorize/user.rb
+++ b/app/services/authorize/user.rb
@@ -41,6 +41,7 @@ module Authorize
       ApiValidations::ApiErrorValidationResponse.new(:user_access_unauthorized) unless decoded_token[0]['roles'].include?(ENV['ACCESS_MANAGE_SUBSCRIPTIONS'])
     end
 
+    # rubocop:disable Style/GuardClause
     def validate_service_eligibility_or_ccs_admin_user
       decoded_token = validate_and_decode_token
       if decoded_token[0]['roles'].include?(ENV.fetch('ACCESS_ORGANISATION_ADMIN', nil)) && decoded_token[0]['roles'].exclude?(ENV.fetch('ACCESS_MANAGE_SUBSCRIPTIONS', nil))
@@ -53,6 +54,7 @@ module Authorize
 
       ApiValidations::ApiErrorValidationResponse.new(:user_access_unauthorized)
     end
+    # rubocop:enable Style/GuardClause
 
     def registered_orgs_controller_role_check
       decoded_token = Common::ApiHelper.decode_token(request.headers)


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/CON-1373**
Fixes issue where Admin and MSE role could not search for other orgs, as is expected for MSE.