### PR TITLE
CON-3126-Update-Postcode-Handling-When-Missing

### DIFF
--- a/app/controllers/api/v1/organisations_controller.rb
+++ b/app/controllers/api/v1/organisations_controller.rb
@@ -3,7 +3,7 @@ module Api
     class OrganisationsController < ActionController::API
       include Authorize::Token
       rescue_from ApiValidations::ApiError, with: :return_error_code
-      #before_action :validate_api_key
+      before_action :validate_api_key
       before_action :validate_params
 
       def search_organisation

--- a/app/controllers/api/v1/organisations_controller.rb
+++ b/app/controllers/api/v1/organisations_controller.rb
@@ -3,7 +3,7 @@ module Api
     class OrganisationsController < ActionController::API
       include Authorize::Token
       rescue_from ApiValidations::ApiError, with: :return_error_code
-      before_action :validate_api_key
+      #before_action :validate_api_key
       before_action :validate_params
 
       def search_organisation

--- a/app/services/companies_house/address.rb
+++ b/app/services/companies_house/address.rb
@@ -28,7 +28,10 @@ module CompaniesHouse
     end
 
     def postal_code
-      exists_or_null(@result['registered_office_address']['postal_code'])
+      # Temporary tactical fix, until PPG allows empty postcode string. This is scoped for a future sprint.
+      api_param = @result['registered_office_address']['postal_code']
+
+      api_param.present? ? api_param : 'NA'
     end
 
     def region

--- a/app/services/dnb/address.rb
+++ b/app/services/dnb/address.rb
@@ -28,7 +28,10 @@ module Dnb
     end
 
     def postal_code
-      exists_or_null(@result['organization']['primaryAddress']['postalCode'])
+      # Temporary tactical fix, until PPG allows empty postcode string. This is scoped for a future sprint.
+      api_param = @result['organization']['primaryAddress']['postalCode']
+
+      api_param.present? ? api_param : 'NA'
     end
 
     def country_name

--- a/app/services/find_that_charity/address.rb
+++ b/app/services/find_that_charity/address.rb
@@ -28,7 +28,10 @@ module FindThatCharity
     end
 
     def postal_code
-      exists_or_null(@result['address']['postalCode'])
+      # Temporary tactical fix, until PPG allows empty postcode string. This is scoped for a future sprint.
+      api_param = @result['address']['postalCode']
+
+      api_param.present? ? api_param : 'NA'
     end
 
     def country_name

--- a/app/services/nhs/address.rb
+++ b/app/services/nhs/address.rb
@@ -36,7 +36,10 @@ module Nhs
     end
 
     def postal_code
-      exists_or_null(@result['Organisation']['GeoLoc']['Location']['PostCode'])
+      # Temporary tactical fix, until PPG allows empty postcode string. This is scoped for a future sprint.
+      api_param = @result['Organisation']['GeoLoc']['Location']['PostCode']
+
+      api_param.present? ? api_param : 'NA'
     end
 
     def country_name


### PR DESCRIPTION
Adds extra postcode handling for all the registry identifiers, when the external registry does not return a postcode. Will instead return NA, as requested by PPG.