### PR TITLE
CON-3383-Update-NHS-Scheme-Search-Bug-Fixes

### DIFF
--- a/app/controllers/api/v1/organisations_controller.rb
+++ b/app/controllers/api/v1/organisations_controller.rb
@@ -16,7 +16,7 @@ module Api
       end
 
       def validate_params
-        params[:id] = params[:id].upcase if params[:scheme] == Common::AdditionalIdentifier::SCHEME_DFE
+        params[:id] = params[:id].upcase if params[:scheme].upcase == Common::AdditionalIdentifier::SCHEME_NHS
         validate = ApiValidations::Scheme.new(params, return_organisation_id: true)
         render json: validate.errors, status: :bad_request unless params[:id] == Common::AdditionalIdentifier::MOCK_ID || validate.valid?
       end


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/CON-3383**
Update NHS registry search, so that a lower case identifier finds correct org record.