### PR TITLE
PPG-252-Remove-PPON-From-Schemes-Page

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,8 +13,7 @@
   {scheme_name: 'The Charity Commission for Northern Ireland', scheme_register_code: 'GB-NIC', scheme_uri: 'https://findthatcharity.uk', scheme_country_code: 'GB', scheme_identifier: 'Registered Charity Number'},
   {scheme_name: 'National Health Service Organisations Registry', scheme_register_code: 'GB-NHS', scheme_uri: 'https://www.crowncommercial.gov.uk', scheme_country_code: 'GB', scheme_identifier: 'NHS Registered Number'},
   {scheme_name: 'Department for Education', scheme_register_code: 'GB-EDU', scheme_uri: 'https://www.crowncommercial.gov.uk', scheme_country_code: 'GB', scheme_identifier: 'Registered DfE URN'},
-  {scheme_name: 'The Crown Commercial Service', scheme_register_code: 'GB-CCS', scheme_uri: 'https://www.crowncommercial.gov.uk', scheme_country_code: 'GB', scheme_identifier: 'Crown Commercial Service Internal Number'},
-  {scheme_name: 'The Crown Commercial Service Public Procurement Organisation Registry', scheme_register_code: 'GB-PPG', scheme_uri: 'https://www.crowncommercial.gov.uk', scheme_country_code: 'GB', scheme_identifier: 'Crown Commercial Service PPON Number'}
+  {scheme_name: 'The Crown Commercial Service', scheme_register_code: 'GB-CCS', scheme_uri: 'https://www.crowncommercial.gov.uk', scheme_country_code: 'GB', scheme_identifier: 'Crown Commercial Service Internal Number'}
 
 ].each do |rec|
   SchemeRegister.find_or_create_by(scheme_name: rec[:scheme_name], scheme_register_code: rec[:scheme_register_code], scheme_uri: rec[:scheme_uri], scheme_country_code: rec[:scheme_country_code], scheme_identifier: rec[:scheme_identifier])


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/PPG-252**
Remove PPON seed, so that DB schemes is not populated with a PPON entry, to ensure it is sufficiently hidden from the UI.