### PR TITLE
Update hash handling to prevent 500

### DIFF
--- a/app/services/companies_house/address.rb
+++ b/app/services/companies_house/address.rb
@@ -16,15 +16,15 @@ module CompaniesHouse
     end
 
     def street_address
-      "#{exists_or_null(@result['registered_office_address']['address_line_1'])}#{street_address_two}"
+      "#{exists_or_null(@result&.dig('registered_office_address','address_line_1'))}#{street_address_two}"
     end
 
     def street_address_two
-      ", #{exists_or_null(@result['registered_office_address']['address_line_2'])}" if exists_or_null(@result['registered_office_address']['address_line_2']).present?
+      ", #{exists_or_null(@result&.dig('registered_office_address','address_line_2'))}" if exists_or_null(@result&.dig('registered_office_address','address_line_2')).present?
     end
 
     def locality
-      exists_or_null(@result['registered_office_address']['locality'])
+      exists_or_null(@result&.dig('registered_office_address','locality'))
     end
 
     def postal_code
@@ -35,11 +35,11 @@ module CompaniesHouse
     end
 
     def region
-      exists_or_null(@result['registered_office_address']['region'])
+      exists_or_null(@result&.dig('registered_office_address','region'))
     end
 
     def country_name
-      country = exists_or_null(@result['registered_office_address']['country'])
+      country = exists_or_null(@result&.dig('registered_office_address','country'))
       country.present? ? country : ''
     end
 

--- a/app/services/companies_house/address.rb
+++ b/app/services/companies_house/address.rb
@@ -16,15 +16,15 @@ module CompaniesHouse
     end
 
     def street_address
-      "#{exists_or_null(@result&.dig('registered_office_address','address_line_1'))}#{street_address_two}"
+      "#{exists_or_null(@result&.dig('registered_office_address', 'address_line_1'))}#{street_address_two}"
     end
 
     def street_address_two
-      ", #{exists_or_null(@result&.dig('registered_office_address','address_line_2'))}" if exists_or_null(@result&.dig('registered_office_address','address_line_2')).present?
+      ", #{exists_or_null(@result&.dig('registered_office_address', 'address_line_2'))}" if exists_or_null(@result&.dig('registered_office_address', 'address_line_2')).present?
     end
 
     def locality
-      exists_or_null(@result&.dig('registered_office_address','locality'))
+      exists_or_null(@result&.dig('registered_office_address', 'locality'))
     end
 
     def postal_code
@@ -35,11 +35,11 @@ module CompaniesHouse
     end
 
     def region
-      exists_or_null(@result&.dig('registered_office_address','region'))
+      exists_or_null(@result&.dig('registered_office_address', 'region'))
     end
 
     def country_name
-      country = exists_or_null(@result&.dig('registered_office_address','country'))
+      country = exists_or_null(@result&.dig('registered_office_address', 'country'))
       country.present? ? country : ''
     end
 

--- a/app/services/companies_house/indentifier.rb
+++ b/app/services/companies_house/indentifier.rb
@@ -15,11 +15,11 @@ module CompaniesHouse
     end
 
     def id
-      exists_or_null(@result['company_number'])
+      exists_or_null(@result&.dig('company_number'))
     end
 
     def legal_name
-      exists_or_null(@result['company_name'])
+      exists_or_null(@result&.dig('company_name'))
     end
 
     private

--- a/app/services/dnb/address.rb
+++ b/app/services/dnb/address.rb
@@ -16,26 +16,26 @@ module Dnb
     end
 
     def street_address
-      "#{exists_or_null(@result['organization']['primaryAddress']['streetAddress']['line1'])}#{street_address_two}"
+      "#{exists_or_null(@result&.dig('organization','primaryAddress','streetAddress','line1'))}#{street_address_two}"
     end
 
     def street_address_two
-      ", #{exists_or_null(@result['organization']['primaryAddress']['streetAddress']['line2'])}" if exists_or_null(@result['organization']['primaryAddress']['streetAddress']['line2']).present?
+      ", #{exists_or_null(@result&.dig('organization','primaryAddress','streetAddress','line2'))}" if @result&.dig('organization', 'primaryAddress', 'streetAddress', 'line2').present?
     end
 
     def locality
-      exists_or_null(@result['organization']['primaryAddress']['addressLocality']['name'])
+      exists_or_null(@result&.dig('organization','primaryAddress','addressLocality','name'))
     end
 
     def postal_code
       # Temporary tactical fix, until PPG allows empty postcode string. This is scoped for a future sprint.
-      api_param = @result['organization']['primaryAddress']['postalCode']
+      api_param = @result&.dig('organization','primaryAddress','postalCode')
 
       api_param.present? ? api_param : 'NA'
     end
 
     def country_name
-      exists_or_null(@result['organization']['primaryAddress']['addressCountry']['name'])
+      exists_or_null(@result&.dig('organization','primaryAddress','addressCountry','name'))
     end
 
     private

--- a/app/services/dnb/address.rb
+++ b/app/services/dnb/address.rb
@@ -16,26 +16,26 @@ module Dnb
     end
 
     def street_address
-      "#{exists_or_null(@result&.dig('organization','primaryAddress','streetAddress','line1'))}#{street_address_two}"
+      "#{exists_or_null(@result&.dig('organization', 'primaryAddress', 'streetAddress', 'line1'))}#{street_address_two}"
     end
 
     def street_address_two
-      ", #{exists_or_null(@result&.dig('organization','primaryAddress','streetAddress','line2'))}" if @result&.dig('organization', 'primaryAddress', 'streetAddress', 'line2').present?
+      ", #{exists_or_null(@result&.dig('organization', 'primaryAddress', 'streetAddress', 'line2'))}" if @result&.dig('organization', 'primaryAddress', 'streetAddress', 'line2').present?
     end
 
     def locality
-      exists_or_null(@result&.dig('organization','primaryAddress','addressLocality','name'))
+      exists_or_null(@result&.dig('organization', 'primaryAddress', 'addressLocality', 'name'))
     end
 
     def postal_code
       # Temporary tactical fix, until PPG allows empty postcode string. This is scoped for a future sprint.
-      api_param = @result&.dig('organization','primaryAddress','postalCode')
+      api_param = @result&.dig('organization', 'primaryAddress', 'postalCode')
 
       api_param.present? ? api_param : 'NA'
     end
 
     def country_name
-      exists_or_null(@result&.dig('organization','primaryAddress','addressCountry','name'))
+      exists_or_null(@result&.dig('organization', 'primaryAddress', 'addressCountry', 'name'))
     end
 
     private

--- a/app/services/dnb/indentifier.rb
+++ b/app/services/dnb/indentifier.rb
@@ -15,11 +15,11 @@ module Dnb
     end
 
     def duns_number
-      exists_or_null(@result['organization']['duns'])
+      exists_or_null(@result&.dig('organization','duns'))
     end
 
     def legal_name
-      exists_or_null(@result['organization']['primaryName'])
+      exists_or_null(@result&.dig('organization','primaryName'))
     end
 
     private

--- a/app/services/dnb/indentifier.rb
+++ b/app/services/dnb/indentifier.rb
@@ -15,11 +15,11 @@ module Dnb
     end
 
     def duns_number
-      exists_or_null(@result&.dig('organization','duns'))
+      exists_or_null(@result&.dig('organization', 'duns'))
     end
 
     def legal_name
-      exists_or_null(@result&.dig('organization','primaryName'))
+      exists_or_null(@result&.dig('organization', 'primaryName'))
     end
 
     private

--- a/app/services/dnb/search.rb
+++ b/app/services/dnb/search.rb
@@ -58,7 +58,7 @@ module Dnb
     end
 
     def name
-      exists_or_null(@result&.dig('organization','primaryName'))
+      exists_or_null(@result&.dig('organization', 'primaryName'))
     end
 
     private

--- a/app/services/dnb/search.rb
+++ b/app/services/dnb/search.rb
@@ -58,7 +58,7 @@ module Dnb
     end
 
     def name
-      exists_or_null(@result['organization']['primaryName'])
+      exists_or_null(@result&.dig('organization','primaryName'))
     end
 
     private

--- a/app/services/dnb_chn/address.rb
+++ b/app/services/dnb_chn/address.rb
@@ -16,23 +16,23 @@ module DnbChn
     end
 
     def street_address
-      "#{exists_or_null(@result&.dig('organization','primaryAddress','streetAddress','line1'))}#{street_address_two}"
+      "#{exists_or_null(@result&.dig('organization', 'primaryAddress', 'streetAddress', 'line1'))}#{street_address_two}"
     end
 
     def street_address_two
-      ", #{exists_or_null(@result&.dig('organization','primaryAddress','streetAddress','line2'))}" if @result&.dig('organization', 'primaryAddress', 'streetAddress', 'line2').present?
+      ", #{exists_or_null(@result&.dig('organization', 'primaryAddress', 'streetAddress', 'line2'))}" if @result&.dig('organization', 'primaryAddress', 'streetAddress', 'line2').present?
     end
 
     def locality
-      exists_or_null(@result&.dig('organization','primaryAddress','addressLocality','name'))
+      exists_or_null(@result&.dig('organization', 'primaryAddress', 'addressLocality', 'name'))
     end
 
     def postal_code
-      exists_or_null(@result&.dig('organization','primaryAddress','postalCode'))
+      exists_or_null(@result&.dig('organization', 'primaryAddress', 'postalCode'))
     end
 
     def country_name
-      exists_or_null(@result&.dig('organization','primaryAddress','addressCountry','name'))
+      exists_or_null(@result&.dig('organization', 'primaryAddress', 'addressCountry', 'name'))
     end
 
     private

--- a/app/services/dnb_chn/address.rb
+++ b/app/services/dnb_chn/address.rb
@@ -16,23 +16,23 @@ module DnbChn
     end
 
     def street_address
-      "#{exists_or_null(@result['organization']['primaryAddress']['streetAddress']['line1'])}#{street_address_two}"
+      "#{exists_or_null(@result&.dig('organization','primaryAddress','streetAddress','line1'))}#{street_address_two}"
     end
 
     def street_address_two
-      ", #{exists_or_null(@result['organization']['primaryAddress']['streetAddress']['line2'])}" if exists_or_null(@result['organization']['primaryAddress']['streetAddress']['line2']).present?
+      ", #{exists_or_null(@result&.dig('organization','primaryAddress','streetAddress','line2'))}" if @result&.dig('organization', 'primaryAddress', 'streetAddress', 'line2').present?
     end
 
     def locality
-      exists_or_null(@result['organization']['primaryAddress']['addressLocality']['name'])
+      exists_or_null(@result&.dig('organization','primaryAddress','addressLocality','name'))
     end
 
     def postal_code
-      exists_or_null(@result['organization']['primaryAddress']['postalCode'])
+      exists_or_null(@result&.dig('organization','primaryAddress','postalCode'))
     end
 
     def country_name
-      exists_or_null(@result['organization']['primaryAddress']['addressCountry']['name'])
+      exists_or_null(@result&.dig('organization','primaryAddress','addressCountry','name'))
     end
 
     private

--- a/app/services/dnb_chn/indentifier.rb
+++ b/app/services/dnb_chn/indentifier.rb
@@ -15,11 +15,11 @@ module DnbChn
     end
 
     def duns_number
-      exists_or_null(@result&.dig('organization','duns'))
+      exists_or_null(@result&.dig('organization', 'duns'))
     end
 
     def legal_name
-      exists_or_null(@result&.dig('organization','primaryName'))
+      exists_or_null(@result&.dig('organization', 'primaryName'))
     end
 
     private

--- a/app/services/dnb_chn/indentifier.rb
+++ b/app/services/dnb_chn/indentifier.rb
@@ -15,11 +15,11 @@ module DnbChn
     end
 
     def duns_number
-      exists_or_null(@result['organization']['duns'])
+      exists_or_null(@result&.dig('organization','duns'))
     end
 
     def legal_name
-      exists_or_null(@result['organization']['primaryName'])
+      exists_or_null(@result&.dig('organization','primaryName'))
     end
 
     private

--- a/app/services/dnb_chn/search.rb
+++ b/app/services/dnb_chn/search.rb
@@ -57,7 +57,7 @@ module DnbChn
     end
 
     def name
-      exists_or_null(@result&.dig('organization','primaryName'))
+      exists_or_null(@result&.dig('organization', 'primaryName'))
     end
 
     private

--- a/app/services/dnb_chn/search.rb
+++ b/app/services/dnb_chn/search.rb
@@ -57,7 +57,7 @@ module DnbChn
     end
 
     def name
-      exists_or_null(@result['organization']['primaryName'])
+      exists_or_null(@result&.dig('organization','primaryName'))
     end
 
     private

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,8 @@
   {scheme_name: 'The Charity Commission for Northern Ireland', scheme_register_code: 'GB-NIC', scheme_uri: 'https://findthatcharity.uk', scheme_country_code: 'GB', scheme_identifier: 'Registered Charity Number'},
   {scheme_name: 'National Health Service Organisations Registry', scheme_register_code: 'GB-NHS', scheme_uri: 'https://www.crowncommercial.gov.uk', scheme_country_code: 'GB', scheme_identifier: 'NHS Registered Number'},
   {scheme_name: 'Department for Education', scheme_register_code: 'GB-EDU', scheme_uri: 'https://www.crowncommercial.gov.uk', scheme_country_code: 'GB', scheme_identifier: 'Registered DfE URN'},
-  {scheme_name: 'The Crown Commercial Service', scheme_register_code: 'GB-CCS', scheme_uri: 'https://www.crowncommercial.gov.uk', scheme_country_code: 'GB', scheme_identifier: 'Crown Commercial Service Internal Number'}
+  {scheme_name: 'The Crown Commercial Service', scheme_register_code: 'GB-CCS', scheme_uri: 'https://www.crowncommercial.gov.uk', scheme_country_code: 'GB', scheme_identifier: 'Crown Commercial Service Internal Number'},
+  {scheme_name: 'The Crown Commercial Service Public Procurement Organisation Registry', scheme_register_code: 'GB-PPG', scheme_uri: 'https://www.crowncommercial.gov.uk', scheme_country_code: 'GB', scheme_identifier: 'Crown Commercial Service PPON Number'}
 
 ].each do |rec|
   SchemeRegister.find_or_create_by(scheme_name: rec[:scheme_name], scheme_register_code: rec[:scheme_register_code], scheme_uri: rec[:scheme_uri], scheme_country_code: rec[:scheme_country_code], scheme_identifier: rec[:scheme_identifier])


### PR DESCRIPTION
Updates Companies and DUNs registries, to prevent a 500 error, if key was missing from hash object.