### PR TITLE
PPG-344-Add-Address-Back-Into-Incorrect-Endpoint

### DIFF
--- a/app/controllers/api/v1/manage_organisations_controller.rb
+++ b/app/controllers/api/v1/manage_organisations_controller.rb
@@ -9,7 +9,7 @@ module Api
       before_action :validate_params
 
       def search_organisation
-        scheme_result = api_result.except(:address, :contactPoint)
+        scheme_result = api_result
         # While PPON is being developed, we want any related CII functionality to be inaccessible temporarily.
         if scheme_result.blank? || params[:scheme].upcase == Common::AdditionalIdentifier::SCHEME_PPON
           render json: '', status: :not_found


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/PPG-344**
Removes Address and ContactPoint fields from the response, of GET endpoints.