### PR TITLE
PPG-475-Update-DM-Controller-When-404-Response-Given

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,9 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.2-x86_64-darwin)
+    nokogiri (1.15.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
     olive_branch (4.0.1)
       multi_json
@@ -349,6 +351,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
     sqlite3 (1.6.3-x86_64-darwin)
+    sqlite3 (1.6.3-x86_64-linux)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.2)
@@ -367,7 +370,6 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
-  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/api/v1/data_migration_controller.rb
+++ b/app/controllers/api/v1/data_migration_controller.rb
@@ -62,6 +62,7 @@ module Api
       def required_identifiers_exist
         return false if @coh_api_results.blank? && @duns_api_results.blank?
         return false if @api_result.blank?
+
         true
       end
 

--- a/app/controllers/api/v1/data_migration_controller.rb
+++ b/app/controllers/api/v1/data_migration_controller.rb
@@ -40,9 +40,9 @@ module Api
       end
 
       def return_success
-        return render json: build_response, status: :created if @api_result.present?
+        return render json: build_response, status: :created if required_identifiers_exist
 
-        render json: '', status: :not_found if @api_result.blank?
+        render json: '', status: :not_found
       end
 
       def mock_id_dm_helper
@@ -56,7 +56,13 @@ module Api
       def create_from_salesforce
         salesforce_api_search
         @sales_force_organisation_created = create_organisation if create_org_check
-        additional_organisation(@api_result, true) if @api_result.present? && !@duplicate_ccs_org_id
+        additional_organisation(@api_result, true) if required_identifiers_exist && !@duplicate_ccs_org_id
+      end
+
+      def required_identifiers_exist
+        return false if @coh_api_results.blank? && @duns_api_results.blank?
+        return false if @api_result.blank?
+        true
       end
 
       def create_from_schemes


### PR DESCRIPTION
**https://crowncommercialservice.atlassian.net/browse/PPG-475**
Update DM controller, so that a 404 is given, when there is no primary identifier found, even though the organisation is found in SF.