### PR TITLE
Update companies_house/search.rb

### DIFF
--- a/app/services/companies_house/search.rb
+++ b/app/services/companies_house/search.rb
@@ -48,7 +48,9 @@ module CompaniesHouse
     end
 
     def additional_identifier_duns
-      duns_search = Spotlight::AdditionalIdentifier.new(@company_reg_number, Common::AdditionalIdentifier::SCHEME_COMPANIES_HOUSE).build_response
+      # Comment this out while we are unable to search Spotlight by Companies Number. (This is a requested feature, so will soon be needed).
+      # By setting duns_search as equal to nil, the lower conditional will handle the rest, as required.
+      duns_search = nil # Spotlight::AdditionalIdentifier.new(@company_reg_number, Common::AdditionalIdentifier::SCHEME_COMPANIES_HOUSE).build_response
 
       if duns_search.present?
         [duns_search]


### PR DESCRIPTION
Remove additional Identifier checking for DUNs, after the Primary Companies House Identifier has been found, (since Spotlight does not yet support this).