### PR TITLE
Security-Request--fix-unhandled-routing

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,5 @@
 class ApplicationController < ActionController::API
+  def route_not_found
+    render json: { message: 'Not Found' }, status: :not_found
+  end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,5 @@
+class ErrorsController < ApplicationController
+  def not_found
+    render json: { error: 'Route not found' }, status: :not_found
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,4 +43,6 @@ Rails.application.routes.draw do
       end
     end
   end
+
+  match '*unmatched', to: 'application#route_not_found', via: :all
 end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Errors", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
Security got in touch to handle all unmatched endpoints, so they don't return a stack trace. I.e. handle 404 gracefully